### PR TITLE
Semantic navigation and cross references

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,9 +127,9 @@
         "command": "ccls.vars"
       },
       {
-        "title": "Show Callers",
+        "title": "Show Cross References",
         "category": "ccls",
-        "command": "ccls.callers"
+        "command": "ccls.call"
       },
       {
         "title": "Show Base",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -391,7 +391,11 @@ export function activate(context: ExtensionContext) {
     function makeRefHandler(
         methodName: string, extraParams: object = {},
         autoGotoIfSingle = false) {
-      return () => {
+      return (userParams) => {
+        /* 
+        userParams: a dict defined as `args` in keybindings.json (or passed by other extensions like VSCodeVIM)
+        Values defined by user have higher priority than `extraParams`
+        */
         let position = window.activeTextEditor.selection.active;
         let uri = window.activeTextEditor.document.uri;
         languageClient
@@ -401,6 +405,7 @@ export function activate(context: ExtensionContext) {
               },
               position: position,
               ...extraParams,
+              ...userParams
             })
             .then((locations: Array<ls.Location>) => {
               if (autoGotoIfSingle && locations.length == 1) {
@@ -416,7 +421,7 @@ export function activate(context: ExtensionContext) {
       }
     }
     commands.registerCommand('ccls.vars', makeRefHandler('$ccls/vars'));
-    commands.registerCommand('ccls.callers', makeRefHandler('$ccls/call'));
+    commands.registerCommand('ccls.call', makeRefHandler('$ccls/call'));
     commands.registerCommand(
       'ccls.base', makeRefHandler('$ccls/inheritance', {derived: false}, true));
   })();
@@ -431,7 +436,6 @@ export function activate(context: ExtensionContext) {
               'editor.action.showReferences', p2c.asUri(uri),
               p2c.asPosition(position), locations.map(p2c.asLocation));
         });
-
 
     commands.registerCommand(
         'ccls.goto',
@@ -847,5 +851,32 @@ export function activate(context: ExtensionContext) {
             }
           });
     });
+  })();
+
+  // Semantic navigation
+  (() => {
+    function makeNavigateHandler(methodName) {
+      return (userParams) => {
+        let position = window.activeTextEditor.selection.active;
+        let uri = window.activeTextEditor.document.uri;
+        languageClient
+          .sendRequest<Array<ls.Location>>(methodName, {
+              textDocument: {
+                uri: uri.toString(),
+              },
+              position: position,
+              ...userParams
+            })
+            .then((locations: Array<ls.Location>) => {
+              if (locations.length == 1){
+                let location = p2c.asLocation(locations[0]);
+                jumpToUriAtPosition(
+                    location.uri, location.range.start,
+                    false /*preserveFocus*/);
+              }
+            })
+      }
+    }
+    commands.registerCommand('ccls.navigate', makeNavigateHandler('$ccls/navigate'))
   })();
 }


### PR DESCRIPTION
- Cross References 
  - Demo: show callees upto 3rd level
  ![demo](https://user-images.githubusercontent.com/2814357/45976249-d2cc1a00-c078-11e8-9ac0-12e973dfe29e.gif)
  Just like https://github.com/MaskRay/vscode-ccls/issues/1#issuecomment-424109558
  - The command is changed from "caller" to "call" to be consistent with Emacs. Users could set parameters like `"args": { "levels": 2, "callee": true }`  in keybindings.json or some extensions (like VSCodeVim). They will be passed to `ccls`.
- Semantic navigation: As discussed in #3 , the command is now `ccls.navigate`. Unlike the command above, this command could not be used without an argument. So I need to add some documentation to Wiki

cc @Riatre 