### PR TITLE
indicate in description of regex options that they are parital matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -674,12 +674,12 @@
         "ccls.index.whitelist": {
           "type": "array",
           "default": [],
-          "description": "If a translation unit's absolute path matches any ECMAScript regex in this list, it will be indexed. The whitelist takes priority over the blacklist. To only index files in the whitelist, make \"ccls.index.blacklist\" match everything, ie, set it to \".*\".\n\nYou probably want to begin the regex using \".*\" because the passed paths are absolute."
+          "description": "If a translation unit's absolute path partially matches any ECMAScript regex in this list, it will be indexed. The whitelist takes priority over the blacklist. To only index files in the whitelist, make \"ccls.index.blacklist\" match everything, ie, set it to \".*\"."
         },
         "ccls.index.blacklist": {
           "type": "array",
           "default": [],
-          "description": "A translation unit (cc/cpp file) is not indexed if any of the ECMAScript regexes in this list matches translation unit's the absolute path.\n\nYou probably want to begin the regex using \".*\" because the passed paths are absolute."
+          "description": "A translation unit (cc/cpp file) is not indexed if any of the ECMAScript regexes in this list partially matches translation unit's the absolute path."
         },
         "ccls.clang.resourceDir": {
           "type": "string",
@@ -718,12 +718,12 @@
         "ccls.completion.include.whitelist": {
           "type": "array",
           "default": [],
-          "description": "ECMAScript regex that checks absolute file path. If it does not match, the file is not added to include path auto-complete. An example is \".*/src/.*\""
+          "description": "ECMAScript regex that checks absolute file path. If it does not partially match, the file is not added to include path auto-complete. An example is \"/src/\""
         },
         "ccls.completion.include.blacklist": {
           "type": "array",
           "default": [],
-          "description": "ECMAScript regex that checks absolute path. If it matches, the file is not added to include path auto-complete. An example is \".*/CACHE/.*\""
+          "description": "ECMAScript regex that checks absolute path. If it partially matches, the file is not added to include path auto-complete. An example is \"/CACHE/\""
         },
         "ccls.completion.caseSensitivity": {
           "type": "integer",


### PR DESCRIPTION
our list of 22 blacklists took ~3 minutes to execute on our codebase, during which time the ccls extension was AWOL.  removing the surrounding `.*` from each regex took the extension startup time down to a few seconds.  d605217c1 in ccls main codebase changed `std::regex_match` to `std::regex_search`, so might as well prevent other people from falling into this trap, originated in cquery roots.