### PR TITLE
Add an option to disable CodeLens extension-wise

### DIFF
--- a/package.json
+++ b/package.json
@@ -985,6 +985,11 @@
           "default": null,
           "description": "The maximum number of global search (ie, Ctrl+P + #foo) search results to report. For small search strings on large projects there can be a massive number of results (ie, over 1,000,000) so this limit is important to avoid extremely long delays. null means use the default value provided by the ccls language server."
         },
+        "ccls.codeLens.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether the references CodeLens should be shown."
+        },
         "ccls.statusUpdateInterval": {
           "type": "integer",
           "default": 2000,

--- a/src/serverContext.ts
+++ b/src/serverContext.ts
@@ -338,10 +338,10 @@ export class ServerContext implements Disposable {
     token: CancellationToken,
     next: ProvideCodeLensesSignature
   ): Promise<CodeLens[]> {
-    const enableCodeLens = workspace.getConfiguration(undefined, null).get('editor.codeLens');
+    const config = workspace.getConfiguration('ccls');
+    const enableCodeLens = config.get('codeLens.enabled');
     if (!enableCodeLens)
       return [];
-    const config = workspace.getConfiguration('ccls');
     const enableInlineCodeLens = config.get('codeLens.renderInline', false);
     if (!enableInlineCodeLens) {
       const uri = document.uri;


### PR DESCRIPTION
Some users may want to see CodeLens provided by other extensions, so they do not want to disable `editor.codeLens`.

And CodeLens providers won't be called at all if `editor.codeLens` is false, which means the original check is pointless.