### PR TITLE
 Cleanup config mapping logic in getClientConfig & expose index.maxInitializerLines

### DIFF
--- a/package.json
+++ b/package.json
@@ -934,6 +934,11 @@
           "default": 2,
           "description": "Whether to reparse a file if write times of its dependencies have changed. The file will always be reparsed if its own write time changes.\n\n0: no, 1: only during initial load of project, 2: yes"
         },
+        "ccls.index.maxInitializerLines": {
+          "type": "integer",
+          "default": 15,
+          "description": "Number of lines of the initializer / macro definition showed in hover."
+        },
         "ccls.codeLens.renderInline": {
           "type": "boolean",
           "default": false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,18 +7,12 @@ export interface Icon {
 }
 
 export interface ClientConfig {
-  cache: {
-    directory: string,
-  };
   highlight: {
-    enabled: boolean;
+    blacklist: string[];
     lsRanges: boolean;
   };
   launchArgs: string[];
   launchCommand: string;
-  workspaceSymbol: {
-    sort: boolean,
-  };
   statusUpdateInterval: number;
   traceEndpoint: string;
   [key: string]: any;


### PR DESCRIPTION
* Populate ClientConfig with all keys from VS Code WorkspaceConfiguration (except those in blacklist) instead of a preset list.
With this change, it is possible to send initializationOptions to ccls even if there is no corresponding configuration declaration in package.json. So new initializationOption exposed in ccls no longer necessarily reuqires an update of vscode-ccls.
Declarations in package.json are still useful as they still provide documentations and default values.
* No longer add workspaceSymbol.sort = false by default as this works poorly when there are too many symbols.
* Add documentation of index.maxInitializerLines; set default value to 15