### PR TITLE
Add LD_LIBRARY_PATH to ccls environment

### DIFF
--- a/src/serverContext.ts
+++ b/src/serverContext.ts
@@ -434,6 +434,7 @@ export class ServerContext implements Disposable {
       'PATH',
       'CPATH',
       'LIBRARY_PATH',
+      'LD_LIBRARY_PATH'
     ];
     for (const e of kToForward)
       env[e] = process.env[e];

--- a/src/serverContext.ts
+++ b/src/serverContext.ts
@@ -428,21 +428,10 @@ export class ServerContext implements Disposable {
   private initClient(): LanguageClient {
     const args = this.cliConfig.launchArgs;
 
-    const env: any = {};
-    const kToForward = [
-      'ProgramData',
-      'PATH',
-      'CPATH',
-      'LIBRARY_PATH',
-      'LD_LIBRARY_PATH'
-    ];
-    for (const e of kToForward)
-      env[e] = process.env[e];
-
     const serverOptions: ServerOptions = async (): Promise<cp.ChildProcess> => {
       const opts: cp.SpawnOptions = {
         cwd: this.cwd,
-        env
+        env: process.env
       };
       const child = cp.spawn(
         this.cliConfig.launchCommand,


### PR DESCRIPTION
This is required if ccls is built with updated libraries than available on the system by default. If this is not passed on to ccls, the dynamic linking of it will fail, as it will try to use the outdated C++ libraries from the system.