### PR TITLE
fixed/improved member hierarchy info

### DIFF
--- a/src/hierarchies/memberHierarchy.ts
+++ b/src/hierarchies/memberHierarchy.ts
@@ -9,6 +9,7 @@ enum MemberKind {
 }
 
 interface MemberHierarchyNode extends IHierarchyNode {
+  fieldName: string;
   children: MemberHierarchyNode[];
 }
 
@@ -22,7 +23,20 @@ export class MemberHierarchyProvider extends Hierarchy<MemberHierarchyNode> {
   }
 
   public onTreeItem(ti: TreeItem, element: MemberHierarchyNode) {
-    //
+    const parts: string[]  = element.fieldName.trim().split(' ');
+    const off: number = parseInt(parts[0], 10);
+    let fieldName: string = '';
+    if (isNaN(off) || (parts.length < 3)) {
+      fieldName = parts[1];
+    } else {
+      fieldName = parts[2];
+      ti.tooltip = `Offset: ${off} bytes`;
+    }
+
+    if (fieldName !== undefined) {
+      ti.label = fieldName;
+      ti.description = `(${element.name}) ` + ti.description;
+    }
   }
 
   protected async onGetChildren(element: MemberHierarchyNode): Promise<MemberHierarchyNode[]> {


### PR DESCRIPTION
here it shows names of fields as well as their types
+ byte offset of particular field in the tooltip

would also be nice to show a sizeof for each field, but that requires also some changes on the ccls side