### PR TITLE
Redesign semantic highlight configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccls",
-  "description": "C/C++/ObjC language server supporting cross references, hierarchies, completion and semantic highlighting",
+  "description": "C/C++/ObjC language server supporting cross references, hierarchies, completion and semantic highlight",
   "author": "ccls-project",
   "license": "MIT",
   "version": "0.1.23",
@@ -271,82 +271,94 @@
           "default": false,
           "description": "If false, store cache files as $directory/@a@b/c.cc.blob\n\nIf true, $directory/a/b/c.cc.blob."
         },
-        "ccls.highlighting.enabled.types": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for classes, structs, and unions is enabled/disabled."
+
+        "ccls.highlight.function.face": {
+          "type": "array",
+          "default": []
         },
-        "ccls.highlighting.enabled.freeStandingFunctions": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for member functions is enabled/disabled."
+        "ccls.highlight.global.face": {
+          "type": "array",
+          "default": ["fontWeight: bolder"]
         },
-        "ccls.highlighting.enabled.memberFunctions": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for member functions is enabled/disabled."
+        "ccls.highlight.member.face": {
+          "type": "array",
+          "default": ["fontStyle: italic"]
         },
-        "ccls.highlighting.enabled.freeStandingVariables": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for member free-standing variables is enabled/disabled."
+        "ccls.highlight.static.face": {
+          "type": "array",
+          "default": ["fontWeight: bold"]
         },
-        "ccls.highlighting.enabled.memberVariables": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for member variables is enabled/disabled."
+        "ccls.highlight.type.face": {
+          "type": "array",
+          "default": []
         },
-        "ccls.highlighting.enabled.namespaces": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for namespaces is enabled/disabled."
+        "ccls.highlight.variable.face": {
+          "type": "array",
+          "default": []
         },
-        "ccls.highlighting.enabled.macros": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for macros is enabled/disabled."
+
+        "ccls.highlight.enum.face": {
+          "type": "array",
+          "default": ["variable", "member"]
         },
-        "ccls.highlighting.enabled.enums": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for enumerations is enabled/disabled."
+        "ccls.highlight.globalVariable.face": {
+          "type": "array",
+          "default": ["variable", "global"]
         },
-        "ccls.highlighting.enabled.typeAliases": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for type aliases is enabled/disabled."
+        "ccls.highlight.macro.face": {
+          "type": "array",
+          "default": ["variable"]
         },
-        "ccls.highlighting.enabled.enumConstants": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for enumerators is enabled/disabled."
+        "ccls.highlight.memberFunction.face": {
+          "type": "array",
+          "default": ["function", "member"]
         },
-        "ccls.highlighting.enabled.staticMemberFunctions": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for static member functions is enabled/disabled."
+        "ccls.highlight.memberVariable.face": {
+          "type": "array",
+          "default": ["variable", "member"]
         },
-        "ccls.highlighting.enabled.parameters": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for parameters is enabled/disabled."
+        "ccls.highlight.namespace.face": {
+          "type": "array",
+          "default": ["type"]
         },
-        "ccls.highlighting.enabled.templateParameters": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for template parameters is enabled/disabled."
+        "ccls.highlight.parameter.face": {
+          "type": "array",
+          "default": ["variable"]
         },
-        "ccls.highlighting.enabled.staticMemberVariables": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for static member variables is enabled/disabled."
+        "ccls.highlight.staticMemberFunction.face": {
+          "type": "array",
+          "default": ["function", "static"]
         },
-        "ccls.highlighting.enabled.globalVariables": {
-          "type": "boolean",
-          "default": false,
-          "description": "If semantic highlighting for global variables is enabled/disabled."
+        "ccls.highlight.staticMemberVariable.face": {
+          "type": "array",
+          "default": ["variable", "static"]
         },
-        "ccls.highlighting.colors.types": {
+        "ccls.highlight.staticVariable.face": {
+          "type": "array",
+          "default": ["variable", "static"]
+        },
+        "ccls.highlight.typeAlias.face": {
+          "type": "array",
+          "default": ["type"]
+        },
+
+        "ccls.highlight.function.colors": {
+          "type": "array",
+          "default": [
+            "#e5b124",
+            "#927754",
+            "#eb992c",
+            "#e2bf8f",
+            "#d67c17",
+            "#88651e",
+            "#e4b953",
+            "#a36526",
+            "#b28927",
+            "#d69855"
+          ],
+          "description": "Colors to use for semantic highlight. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlight will cycle through them for successive symbols."
+        },
+        "ccls.highlight.type.colors": {
           "type": "array",
           "default": [
             "#e1afc3",
@@ -360,41 +372,9 @@
             "#dd7a90",
             "#e0438a"
           ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
+          "description": "Colors to use for semantic highlight. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlight will cycle through them for successive symbols."
         },
-        "ccls.highlighting.colors.freeStandingFunctions": {
-          "type": "array",
-          "default": [
-            "#e5b124",
-            "#927754",
-            "#eb992c",
-            "#e2bf8f",
-            "#d67c17",
-            "#88651e",
-            "#e4b953",
-            "#a36526",
-            "#b28927",
-            "#d69855"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.memberFunctions": {
-          "type": "array",
-          "default": [
-            "#e5b124",
-            "#927754",
-            "#eb992c",
-            "#e2bf8f",
-            "#d67c17",
-            "#88651e",
-            "#e4b953",
-            "#a36526",
-            "#b28927",
-            "#d69855"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.freeStandingVariables": {
+        "ccls.highlight.variable.colors": {
           "type": "array",
           "default": [
             "#587d87",
@@ -408,25 +388,9 @@
             "#48a5af",
             "#7ca6b7"
           ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
+          "description": "Colors to use for semantic highlight. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlight will cycle through them for successive symbols."
         },
-        "ccls.highlighting.colors.memberVariables": {
-          "type": "array",
-          "default": [
-            "#587d87",
-            "#26cdca",
-            "#397797",
-            "#57c2cc",
-            "#306b72",
-            "#6cbcdf",
-            "#368896",
-            "#3ea0d2",
-            "#48a5af",
-            "#7ca6b7"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.namespaces": {
+        "ccls.highlight.namespace.colors": {
           "type": "array",
           "default": [
             "#429921",
@@ -440,9 +404,9 @@
             "#58bf89",
             "#3e9f4a"
           ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
+          "description": "Colors to use for semantic highlight. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlight will cycle through them for successive symbols."
         },
-        "ccls.highlighting.colors.macros": {
+        "ccls.highlight.macro.colors": {
           "type": "array",
           "default": [
             "#e79528",
@@ -456,316 +420,9 @@
             "#e27a71",
             "#cf6d49"
           ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
+          "description": "Colors to use for semantic highlight. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlight will cycle through them for successive symbols."
         },
-        "ccls.highlighting.colors.enums": {
-          "type": "array",
-          "default": [
-            "#e1afc3",
-            "#d533bb",
-            "#9b677f",
-            "#e350b6",
-            "#a04360",
-            "#dd82bc",
-            "#de3864",
-            "#ad3f87",
-            "#dd7a90",
-            "#e0438a"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.typeAliases": {
-          "type": "array",
-          "default": [
-            "#e1afc3",
-            "#d533bb",
-            "#9b677f",
-            "#e350b6",
-            "#a04360",
-            "#dd82bc",
-            "#de3864",
-            "#ad3f87",
-            "#dd7a90",
-            "#e0438a"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.staticMemberFunctions": {
-          "type": "array",
-          "default": [
-            "#e5b124",
-            "#927754",
-            "#eb992c",
-            "#e2bf8f",
-            "#d67c17",
-            "#88651e",
-            "#e4b953",
-            "#a36526",
-            "#b28927",
-            "#d69855"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.enumConstants": {
-          "type": "array",
-          "default": [
-            "#587d87",
-            "#26cdca",
-            "#397797",
-            "#57c2cc",
-            "#306b72",
-            "#6cbcdf",
-            "#368896",
-            "#3ea0d2",
-            "#48a5af",
-            "#7ca6b7"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.parameters": {
-          "type": "array",
-          "default": [
-            "#587d87",
-            "#26cdca",
-            "#397797",
-            "#57c2cc",
-            "#306b72",
-            "#6cbcdf",
-            "#368896",
-            "#3ea0d2",
-            "#48a5af",
-            "#7ca6b7"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.templateParameters": {
-          "type": "array",
-          "default": [
-            "#e1afc3",
-            "#d533bb",
-            "#9b677f",
-            "#e350b6",
-            "#a04360",
-            "#dd82bc",
-            "#de3864",
-            "#ad3f87",
-            "#dd7a90",
-            "#e0438a"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.staticMemberVariables": {
-          "type": "array",
-          "default": [
-            "#587d87",
-            "#26cdca",
-            "#397797",
-            "#57c2cc",
-            "#306b72",
-            "#6cbcdf",
-            "#368896",
-            "#3ea0d2",
-            "#48a5af",
-            "#7ca6b7"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.colors.globalVariables": {
-          "type": "array",
-          "default": [
-            "#587d87",
-            "#26cdca",
-            "#397797",
-            "#57c2cc",
-            "#306b72",
-            "#6cbcdf",
-            "#368896",
-            "#3ea0d2",
-            "#48a5af",
-            "#7ca6b7"
-          ],
-          "description": "Colors to use for semantic highlighting. A good generator is http://tools.medialab.sciences-po.fr/iwanthue/. If multiple colors are specified, semantic highlighting will cycle through them for successive symbols."
-        },
-        "ccls.highlighting.underline.types": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.freeStandingFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.memberFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.freeStandingVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.memberVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.namespaces": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.macros": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.enums": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.typeAliases": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.enumConstants": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.staticMemberFunctions": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.underline.parameters": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.templateParameters": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.underline.staticMemberVariables": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.underline.globalVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.types": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.freeStandingFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.memberFunctions": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.italic.freeStandingVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.memberVariables": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.italic.namespaces": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.macros": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.enums": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.typeAliases": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.enumConstants": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.staticMemberFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.parameters": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.italic.templateParameters": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.staticMemberVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.italic.globalVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.types": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.bold.freeStandingFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.memberFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.freeStandingVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.memberVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.namespaces": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.bold.macros": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.enums": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.bold.typeAliases": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.bold.enumConstants": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.bold.staticMemberFunctions": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.parameters": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.templateParameters": {
-          "type": "boolean",
-          "default": true
-        },
-        "ccls.highlighting.bold.staticMemberVariables": {
-          "type": "boolean",
-          "default": false
-        },
-        "ccls.highlighting.bold.globalVariables": {
-          "type": "boolean",
-          "default": false
-        },
+
         "ccls.clang.extraArgs": {
           "type": "array",
           "default": [],
@@ -891,7 +548,7 @@
             "null"
           ],
           "default": null,
-          "description": "Files that match these patterns won't have semantic highlighting."
+          "description": "Files that match these patterns won't have semantic highlight."
         },
         "ccls.highlight.whitelist": {
           "type": [
@@ -899,7 +556,7 @@
             "null"
           ],
           "default": null,
-          "description": "Files that match these patterns will have semantic highlighting."
+          "description": "Files that match these patterns will have semantic highlight."
         },
         "ccls.highlight.largeFileSize": {
           "type": [
@@ -907,7 +564,7 @@
             "null"
           ],
           "default": null,
-          "description": "Disable semantic highlighting for files larger than the size."
+          "description": "Disable semantic highlight for files larger than the size."
         },
         "ccls.index.initialBlacklist": {
           "type": "array",

--- a/src/semantic.ts
+++ b/src/semantic.ts
@@ -20,7 +20,6 @@ enum CclsSymbolKind {
 }
 
 enum StorageClass {
-  Invalid,
   None,
   Extern,
   Static,
@@ -31,8 +30,8 @@ enum StorageClass {
 
 interface SemanticSymbol {
   readonly id: number;
-  readonly parentKind: SymbolKind;
-  readonly kind: SymbolKind;
+  readonly parentKind: SymbolKind|CclsSymbolKind;
+  readonly kind: SymbolKind|CclsSymbolKind;
   readonly isTypeMember: boolean;
   readonly storage: StorageClass;
   readonly lsRanges: Range[];
@@ -43,50 +42,23 @@ export interface PublishSemanticHighlightArgs {
   readonly symbols: SemanticSymbol[];
 }
 
-function makeSemanticDecorationType(
-  color: string|undefined, underline: boolean, italic: boolean,
-  bold: boolean): TextEditorDecorationType {
-  const opts: DecorationRenderOptions = {};
-  opts.rangeBehavior = DecorationRangeBehavior.ClosedClosed;
-  opts.color = color;
-  if (underline === true)
-    opts.textDecoration = 'underline';
-  if (italic === true)
-    opts.fontStyle = 'italic';
-  if (bold === true)
-    opts.fontWeight = 'bold';
-  return window.createTextEditorDecorationType(
-      opts as DecorationRenderOptions);
-}
+export const semanticKinds: string[] = [
+  'function',
+  'variable',
+  'type',
 
-export const semanticTypes: {[name: string]: Array<SymbolKind|CclsSymbolKind>} = {
-  enumConstants: [SymbolKind.EnumMember],
-  enums: [SymbolKind.Enum],
-  freeStandingFunctions: [SymbolKind.Function],
-  freeStandingVariables: [],
-  globalVariables: [],
-  macros: [CclsSymbolKind.Macro],
-  memberFunctions: [SymbolKind.Method, SymbolKind.Constructor],
-  memberVariables: [SymbolKind.Field],
-  namespaces: [SymbolKind.Namespace],
-  parameters: [CclsSymbolKind.Parameter],
-  staticMemberFunctions: [CclsSymbolKind.StaticMethod],
-  staticMemberVariables: [],
-  templateParameters: [SymbolKind.TypeParameter],
-  typeAliases: [CclsSymbolKind.TypeAlias],
-  types: [SymbolKind.Class, SymbolKind.Struct],
-};
-
-function makeDecorations(type: string) {
-  const config = workspace.getConfiguration('ccls');
-  let colors = config.get(`highlighting.colors.${type}`, [undefined]);
-  if (colors.length === 0)
-    colors = [undefined];
-  const u = config.get(`highlighting.underline.${type}`, false);
-  const i = config.get(`highlighting.italic.${type}`, false);
-  const b = config.get(`highlighting.bold.${type}`, false);
-  return colors.map((c) => makeSemanticDecorationType(c, u, i, b));
-}
+  'enum',
+  'globalVariable',
+  'macro',
+  'memberFunction',
+  'memberVariable',
+  'namespace',
+  'parameter',
+  'staticMemberFunction',
+  'staticMemberVariable',
+  'staticVariable',
+  'typeAlias',
+]
 
 // TODO: enable bold/italic decorators, might need change in vscode
 export class SemanticContext implements Disposable {
@@ -96,11 +68,6 @@ export class SemanticContext implements Disposable {
   private _dispose: Disposable[] = [];
 
   public constructor() {
-    for (const type of Object.keys(semanticTypes)) {
-      this.semanticDecorations.set(type, makeDecorations(type));
-      this.semanticEnabled.set(type, false);
-    }
-
     this.updateConfigValues();
 
     window.onDidChangeActiveTextEditor(
@@ -119,8 +86,6 @@ export class SemanticContext implements Disposable {
   }
 
   public publishSemanticHighlight(args: PublishSemanticHighlightArgs) {
-    this.updateConfigValues();
-
     const normUri = normalizeUri(args.uri);
 
     for (const visibleEditor of window.visibleTextEditors) {
@@ -150,10 +115,50 @@ export class SemanticContext implements Disposable {
   }
 
   private updateConfigValues() {
-    // Fetch new config instance, since vscode will cache the previous one.
     const config = workspace.getConfiguration('ccls');
-    for (const [name, _value] of this.semanticEnabled) {
-      this.semanticEnabled.set(name, config.get(`highlighting.enabled.${name}`, false));
+
+    for (const kind of semanticKinds) {
+      let face = config.get<string[]>(`highlight.${kind}.face`, []);
+      let enabled = false;
+      let colors = config.get<Array<undefined|string>>(`highlight.${kind}.colors`, []);
+      let props: string[][] = [];
+
+      let stack: [string[], number][] = [[face, 0]];
+      let visited = new Set([kind]);
+      while (stack.length > 0) {
+        const top = stack[stack.length-1];
+        if (top[1] >= top[0].length) {
+          stack.pop();
+          continue;
+        }
+        const f = top[0][top[1]++];
+        if (f === 'enabled')
+          enabled = true;
+        else if (f.indexOf(':') >= 0)
+          props.push(f.split(':'));
+        else {
+          if (visited.has(f))
+            continue;
+          visited.add(f);
+          if (colors.length === 0)
+            colors = config.get<Array<undefined|string>>(`highlight.${f}.colors`, []);
+          const face1 = config.get(`highlight.${f}.face`);
+          if (face1 instanceof Array)
+            stack.push([face1 as string[], 0]);
+        }
+      }
+      this.semanticEnabled.set(kind, enabled);
+
+      if (colors.length === 0)
+        colors = [undefined];
+      this.semanticDecorations.set(kind, colors.map((color) => {
+        const opt: DecorationRenderOptions = {};
+        opt.rangeBehavior = DecorationRangeBehavior.ClosedClosed;
+        opt.color = color;
+        for (const prop of props)
+          (opt as any)[prop[0]] = prop[1].trim();
+        return window.createTextEditorDecorationType(opt as DecorationRenderOptions);
+      }));
     }
   }
 
@@ -167,25 +172,45 @@ export class SemanticContext implements Disposable {
       return decorations[symbol.id % decorations.length];
     };
 
-    if (symbol.kind === SymbolKind.Variable) {
-      if (symbol.parentKind === SymbolKind.Function ||
-          symbol.parentKind === SymbolKind.Method ||
-          symbol.parentKind === SymbolKind.Constructor) {
-        return get('freeStandingVariables');
-      }
-      return get('globalVariables');
-    } else if (symbol.kind === SymbolKind.Field) {
-      if (symbol.storage === StorageClass.Static) {
-        return get('staticMemberVariables');
-      }
-      return get('memberVariables');
-    } else {
-      for (const name of Object.keys(semanticTypes)) {
-        const kinds = semanticTypes[name];
-        if (kinds.some((e) => e === symbol.kind)) {
-          return get(name);
-        }
-      }
+    switch (symbol.kind) {
+    // Functions
+    case SymbolKind.Method:
+    case SymbolKind.Constructor:
+      return get('memberFunction');
+    case SymbolKind.Function:
+      return get('function');
+    case CclsSymbolKind.StaticMethod:
+      return get('staticMemberFunction');
+
+    // Types
+    case SymbolKind.Namespace:
+      return get('namespace');
+    case SymbolKind.Class:
+    case SymbolKind.Struct:
+    case SymbolKind.Enum:
+    case SymbolKind.TypeParameter:
+      return get('type');
+    case CclsSymbolKind.TypeAlias:
+      return get('typeAlias');
+
+    // Variables
+    case SymbolKind.Field:
+      if (symbol.storage == StorageClass.Static)
+        return get('staticMemberVariable');
+      return get('memberVariable');
+    case SymbolKind.Variable:
+      if (symbol.storage == StorageClass.Static)
+        return get('staticVariable');
+      if (symbol.parentKind === SymbolKind.File ||
+          symbol.parentKind === SymbolKind.Namespace)
+        return get('globalVariable');
+      return get('variable');
+    case SymbolKind.EnumMember:
+      return get('enum');
+    case CclsSymbolKind.Parameter:
+      return get('parameter');
+    case CclsSymbolKind.Macro:
+      return get('macro');
     }
   }
 

--- a/src/serverContext.ts
+++ b/src/serverContext.ts
@@ -34,7 +34,7 @@ import { CallHierarchyProvider } from "./hierarchies/callHierarchy";
 import { InheritanceHierarchyProvider } from "./hierarchies/inheritanceHierarchy";
 import { MemberHierarchyProvider } from "./hierarchies/memberHierarchy";
 import { InactiveRegionsProvider } from "./inactiveRegions";
-import { PublishSemanticHighlightArgs, SemanticContext, semanticTypes } from "./semantic";
+import { PublishSemanticHighlightArgs, SemanticContext, semanticKinds } from "./semantic";
 import { StatusBarIconProvider } from "./statusBarIcon";
 import { ClientConfig, IHierarchyNode } from './types';
 import { disposeAll, normalizeUri, unwrap, wait } from "./utils";
@@ -78,9 +78,10 @@ function flatObject(obj: any, pref = ""): Map<string, string> {
 
 function getClientConfig(wsRoot: string): ClientConfig {
   function hasAnySemanticHighlight() {
-    const hlconfig = workspace.getConfiguration('ccls.highlighting.enabled');
-    for (const name of Object.keys(semanticTypes)) {
-      if (hlconfig.get(name, false))
+    const config = workspace.getConfiguration('ccls');
+    for (const kind of semanticKinds) {
+      const face = config.get<string[]>(`highlight.${kind}.face`, []);
+      if (face.length > 0)
         return true;
     }
     return false;
@@ -157,7 +158,7 @@ function getClientConfig(wsRoot: string): ClientConfig {
   const configBlacklist = new Set([
     'codeLens.enabled',
     'codeLens.renderInline',
-    'highlighting',
+    'highlight',
     'misc.showInactiveRegions',
     'theme',
     'trace',
@@ -274,7 +275,7 @@ export class ServerContext implements Disposable {
         "ccls.hackGotoForTreeView", this.hackGotoForTreeView, this
     ));
 
-    // Semantic highlighting
+    // Semantic highlight
     const semantic = new SemanticContext();
     this._dispose.push(semantic);
     this.client.onNotification('$ccls/publishSemanticHighlight',


### PR DESCRIPTION
We currently use a bunch of options to customize styles of various symbol kinds:

```jsonc
// enable semantic highlight for static member functions
"ccls.highlighting.enabled.staticMemberFunctions": true,
// styles
"ccls.highlighting.bold.staticMemberFunctions": true,
"ccls.highlighting.underline.staticMemberFunctions": true,
"ccls.highlighting.italic.staticMemberFunctions": true,

// similar options for other symbol kinds: memberFunctions, freeStandingFunctions, etc
```

This is tedious. This patch changes it to adopt the [approach I used in emacs-ccls](https://github.com/MaskRay/emacs-ccls/blob/master/ccls-semantic-highlight.el).

To enable semantic highlight, add the following lines to `settings.json`:

```jsonc
    "ccls.highlight.type.face": ["enabled"],
    "ccls.highlight.function.face": ["enabled"],
    "ccls.highlight.variable.face": ["enabled"],
```

`function` `type` and `variable` are considered basic symbol kinds. Other symbol kinds inherit styles (bold/italic/underline/etc) and colors from basic symbol kinds. For example, the default `package.json` specifies:

```jsonc
// Mix of function.face and member.face
"ccls.highlight.memberFunction.face": ["function", "member"]
"ccls.highlight.function.face": ["enabled"]
"ccls.highlight.member.face": ["fontStyle: italic"]
```
```jsonc
// Mix of variable.face and global.face
"ccls.highlight.globalVariable.face": ["variable", "global"]
"ccls.highlight.global.face": ["fontWeight: bolder"]
```

To fix the colors of some specific symbol kinds (say `staticMemberFunction`), specify:

```jsonc
 "ccls.highlighting.staticMemberFunctions.colors": [ "#0000c0" ],
```

to override `ccls.highlighting.function.colors` for static member functions.

Available symbol kinds:
```javascript
  'function',
  'variable',
  'type',
  'enum',
  'globalVariable',
  'macro',
  'memberFunction',
  'memberVariable',
  'namespace',
  'parameter',
  'staticMemberFunction',
  'staticVariable',
  'typeAlias',
```