### PR TITLE
initClient() uses server cwd to spawn launcher

### DIFF
--- a/src/serverContext.ts
+++ b/src/serverContext.ts
@@ -435,7 +435,7 @@ export class ServerContext implements Disposable {
     const args = this.cliConfig.launchArgs;
 
     const serverOptions: ServerOptions = async (): Promise<cp.ChildProcess> => {
-      const child = cp.spawn(this.cliConfig.launchCommand, args);
+      const child = cp.spawn(this.cliConfig.launchCommand, args, {cwd: this.cwd});
       this.clientPid = child.pid;
       return child;
     };


### PR DESCRIPTION
As I've mentioned in #114,
Current vscode-ccls will fail if launch command requires `cwd` to be specified.

This PR resolves the issue by setting `cwd` option for spawn() with [server cwd parsed](https://github.com/MaskRay/vscode-ccls/blob/456f21ebf3013abbc553442dd81610f1595310f5/src/globalContext.ts#L30) from `workspace.workspaceFolders`.

It would be better if `cwd` can be configured using `settings.json` but that's out of my hand...